### PR TITLE
Implement API method - Bottom Line for All Site Reviews

### DIFF
--- a/lib/yotpo/api/review.rb
+++ b/lib/yotpo/api/review.rb
@@ -110,5 +110,17 @@ module Yotpo
     def add_vote_to_review(params)
       get("reviews/#{params[:review_id]}/vote/#{params[:vote_value]}")
     end
+
+    #
+    # Retrieve Bottom Line (Total Reviews and Average Score) for All Site Reviews
+    #
+    # @param [Hash] params
+    # @option params [String] :app_key the app key of the account for which the review is created
+    # @option params [String] :utoken the users utoken to get the reviews that are most relevant to that user
+    def get_bottom_line_of_all_site_reviews(params)
+      app_key = params[:app_key]
+
+      get("/products/#{app_key}/yotpo_site_reviews/bottomline")
+    end
   end
 end

--- a/spec/api/review_spec.rb
+++ b/spec/api/review_spec.rb
@@ -82,4 +82,20 @@ describe Yotpo::Review do
     it { should respond_to :id }
 
   end
+
+  describe '#get_bottom_line_of_all_site_reviews' do
+    before(:all) do
+      params = {
+        app_key: @app_key
+      }
+      VCR.use_cassette('get_bottom_line_of_all_site_reviews') do
+        @response = Yotpo.get_bottom_line_of_all_site_reviews(params)
+      end
+    end
+
+    subject { @response.body.bottomline }
+    it { should be_a ::Hashie::Mash }
+    it { should respond_to :average_score }
+    it { should respond_to :total_reviews }
+  end
 end

--- a/spec/cassettes/get_bottom_line_of_all_site_reviews.yml
+++ b/spec/cassettes/get_bottom_line_of_all_site_reviews.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.yotpo.com/products/3ovRYNIb6OIAI0ddS7EfpYkHpi0oTKl6bj82Vjiy/yotpo_site_reviews/bottomline
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Yotpo-Api-Connector:
+      - Ruby1.0.5
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 15 Aug 2018 07:03:06 GMT
+      Etag:
+      - W/"a49221ff8f7c3f816dfcd4e548a09180"
+      P3p:
+      - policyref="/w3c/p3p.xml", CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi
+        CONi HIS OUR IND CNT", CP="CAO PSA OUR"
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - bbb357c2-15ac-4187-9907-63116b03fb1f
+      X-Runtime:
+      - '0.007675'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '104'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status":{"code":200,"message":"OK"},"response":{"bottomline":{"average_score":4.0,"total_reviews":1}}}'
+    http_version: 
+  recorded_at: Wed, 15 Aug 2018 07:03:06 GMT


### PR DESCRIPTION
Implement API method - Bottom Line for All Site Reviews

from documentation:
[Docs: Bottom Line for All Site Reviews](https://apidocs.yotpo.com/reference#v1-retrieve-bottom-line-total-reviews-and-average-score-for-all-products)